### PR TITLE
Yielding Final Clips to prevent Off-By-One Error

### DIFF
--- a/run_plax_hypertrophy_inference.py
+++ b/run_plax_hypertrophy_inference.py
@@ -331,7 +331,10 @@ class PlaxHypertrophyInferenceEngine:
             for p in batch_paths:
                 clips[p][1][batch_map[batch_map['path'] == p]['frame']] = preds[batch_map['path'] == p]
     
-
+        # Yield remaining clips
+        for k, v in clips.items():
+            yield Path(k), v[0], v[1]
+                
     def run_model_np(self, x: np.ndarray) -> np.ndarray:
         """Run inference on a numpy array video.
 


### PR DESCRIPTION
When, at least, this script is run, it will skip writing predictions because the final set of clips are not yielded in _run_on_clips. This resolves that off-by-one error.